### PR TITLE
hook for babelify transpiling

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
     "progress"
   ],
   "author": "numtel <ben@latenightsketches.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "browserify": {
+    "transform": ["babelify"]
+  }
 }


### PR DESCRIPTION
When using progress-promise as a dependency it will not be transpiled to ES5. Added hook for babelify (browserify+babel) to include progress-promise when transpiling.

https://github.com/babel/babelify#why-arent-files-in-node_modules-being-transformed 